### PR TITLE
Fix htoi to return the correct integer equivalent

### DIFF
--- a/02.07-type_conversions/e-2.3-htoi.c
+++ b/02.07-type_conversions/e-2.3-htoi.c
@@ -31,7 +31,10 @@ int htoi(char s[])
     for (j = 0; j <= BASE; ++j)
       {
 	if (tolower(s[i]) == ch[j])
+	{
 	  num = num * 16 + j;
+	  break;
+	}
 	if (j == BASE)
 	  return num;
       }


### PR DESCRIPTION
Issue: the htoi function always returns in the first iteration of the first for (i == 0), because the inner for loop continues to run even after a char was found.
Fix: break the inner for loop after a char was found.
